### PR TITLE
New RTL Fixes

### DIFF
--- a/apps/src/sites/studio/pages/blockly.js
+++ b/apps/src/sites/studio/pages/blockly.js
@@ -22,8 +22,16 @@ Blockly.BlockSvg.prototype.renderDraw_ = function(iconWidth, inputRows) {
       'rect'
     );
     for (const rect_block of rect_blocks) {
+      var check_excluded = rect_block.getAttribute('fill');
       var current_transform = rect_block.getAttribute('transform');
-      if (!current_transform.includes(' scale(-1 1)')) {
+      if (
+        current_transform &&
+        !current_transform.includes(' scale(-1 1)') &&
+        !(
+          check_excluded &&
+          ['url(#pat_11A)', 'url(#pat_12A)'].indexOf(check_excluded) >= 0
+        )
+      ) {
         rect_block.setAttribute(
           'transform',
           current_transform + ' scale(-1 1)'

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3607,3 +3607,8 @@ html[dir=rtl] {
     }
   }
 }
+
+// Dragging canvas must always be LTR to avoid text rendering issues
+.svgDragCanvas {
+  direction: ltr;
+};


### PR DESCRIPTION
1- Fix Dragging Canvas text direction

2- Patch RTL Hack function:
  * Exclude [1,2,3] image from being flipped over inside the jigsaw box
  * Avoid exception caused by (element not found) selector

------------------
Related to https://edraak.atlassian.net/browse/CEO2020-3
Related to https://edraak.atlassian.net/browse/CEO2020-6
Related to https://edraak.atlassian.net/browse/CEO2020-7
